### PR TITLE
Unicode strings problem

### DIFF
--- a/lib/elixir_talk/connect.ex
+++ b/lib/elixir_talk/connect.ex
@@ -28,7 +28,7 @@ defmodule ElixirTalk.Connect do
     pri   = Keyword.get(opts, :pri, 0)
     delay = Keyword.get(opts, :delay, 0)
     ttr   = Keyword.get(opts, :ttr, 60)
-    bytes = String.length(data)
+    bytes = byte_size(data)
     bin_data = "put #{pri} #{delay} #{ttr} #{bytes}\r\n#{data}\r\n"
     :gen_tcp.send(socket, bin_data)
     {:ok, result} = :gen_tcp.recv(socket, 0)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ElixirTalk.Mixfile do
 
   def project do
     [ app: :elixir_talk,
-      version: "1.0.1",
+      version: "1.0.2",
       elixir: "~> 1.0.0",
       description: description,
       package: package,

--- a/test/elixir_talk_test.exs
+++ b/test/elixir_talk_test.exs
@@ -36,6 +36,11 @@ defmodule ElixirTalkTest do
     for id <- [id1, id2, id3, id4], do: ElixirTalk.delete(ctx[:pid], id)
   end
 
+  test "`put` unicode", ctx do
+    {:inserted, id} = ElixirTalk.put ctx[:pid], "hełło"
+    assert is_integer(id)
+  end
+
   test "`use`", ctx do
     {:using, now_tube} = ElixirTalk.list_tube_used(ctx[:pid])
     tube = "not_default"


### PR DESCRIPTION
`String.length` does not counting length of unicode strings well. So we need to use `byte_size`. It returns correct length in all cases.
